### PR TITLE
fix: use different generics for diff input parameters

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,46 +5,46 @@ description = "This is a rust sdk to interact with aiven-cloud apis."
 documentation = "https://docs.rs/aiven-rs"
 edition = "2018"
 homepage = "https://github.com/ansrivas/aiven-rs"
+include = [
+  "**/*.rs",
+  "Cargo.toml",
+]
 keywords = ["sdk", "aiven", "cloud", "infra"]
 license = "MIT"
 name = "aiven_rs"
 readme = "README.md"
 repository = "https://github.com/ansrivas/aiven-rs"
 version = "0.4.1"
-include = [
-    "**/*.rs",
-    "Cargo.toml",
-]
 
 [dependencies]
 tracing = "0.1"
 
 percent-encoding = "2.1.0"
 
+serde = {version = "1.0", features = ["derive"]}
 serde_derive = "1.0"
-serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
+bytes = "1.0"
 thiserror = "1.0"
 url = "2.1"
-bytes= "1.0"
 
 serde_bytes = "0.11"
 
-once_cell= {version = "1.5"}
 mockito = {version = "0.30"}
-tracing-subscriber = {version = "0.3"} 
+once_cell = {version = "1.9"}
+tracing-subscriber = {version = "0.3"}
 
 [dependencies.reqwest]
-default-features=false
+default-features = false
 features = ["json", "rustls-tls"]
-version = "0.11"
+version = "0.11.7"
 
 [dev-dependencies]
 anyhow = "1.0"
 async-compat = "0.2.0"
-tokio = {version="1", features = ["full"]}
 smol = "1.2.5"
+tokio = {version = "1", features = ["full"]}
 
 [lib]
 name = "aiven_rs"
@@ -52,5 +52,5 @@ path = "src/lib.rs"
 
 # https://deterministic.space/high-performance-rust.html
 [profile.release]
-lto = "fat"
 codegen-units = 1
+lto = "fat"

--- a/src/client/aiven_client.rs
+++ b/src/client/aiven_client.rs
@@ -54,10 +54,7 @@ pub struct AivenClient {
 }
 
 impl AivenClient {
-	fn inner_client<T>(base_url: T, token: Option<T>, version: T) -> AivenClient
-	where
-		T: Into<String>,
-	{
+	fn inner_client(base_url: &str, token: Option<&str>, version: &str) -> AivenClient {
 		let mut headers = reqwest::header::HeaderMap::new();
 		headers.insert(
 			"content-type",
@@ -66,7 +63,7 @@ impl AivenClient {
 		if let Some(t) = token {
 			headers.insert(
 				"authorization",
-				HeaderValue::from_str(&format!("aivenv1 {}", &t.into())).unwrap(),
+				HeaderValue::from_str(&format!("aivenv1 {}", t)).unwrap(),
 			);
 		}
 
@@ -77,7 +74,7 @@ impl AivenClient {
 			.unwrap();
 
 		AivenClient {
-			client: HTTPClient::new(base_url.into(), client, version.into()),
+			client: HTTPClient::new(base_url, client, version),
 		}
 	}
 
@@ -96,11 +93,12 @@ impl AivenClient {
 	/// Ok(())
 	/// }
 	/// ```
-	pub fn new<T>(base_url: T, version: T) -> AivenClient
+	pub fn new<T, U>(base_url: T, version: U) -> AivenClient
 	where
 		T: Into<String>,
+		U: Into<String>,
 	{
-		AivenClient::inner_client(base_url, None, version)
+		AivenClient::inner_client(&base_url.into(), None, &version.into())
 	}
 
 	/// Create a new basic client with url, version and token.
@@ -118,11 +116,13 @@ impl AivenClient {
 	/// Ok(())
 	/// }
 	/// ```
-	pub fn from_token<T>(base_url: T, version: T, token: T) -> AivenClient
+	pub fn from_token<T, U, V>(base_url: T, version: U, token: V) -> AivenClient
 	where
 		T: Into<String>,
+		U: Into<String>,
+		V: Into<String>,
 	{
-		AivenClient::inner_client(base_url, Some(token), version)
+		AivenClient::inner_client(&base_url.into(), Some(&token.into()), &version.into())
 	}
 
 	/// Access all the cloud APIs

--- a/src/client/http_client.rs
+++ b/src/client/http_client.rs
@@ -105,14 +105,15 @@ macro_rules! make_request {
 }
 
 impl HTTPClient {
-	pub fn new<S>(base_url: S, client: reqwest::Client, version: String) -> HTTPClient
+	pub fn new<S, T>(base_url: S, client: reqwest::Client, version: T) -> HTTPClient
 	where
 		S: Into<String>,
+		T: Into<String>,
 	{
 		let parsed_url =
 			reqwest::Url::parse(&base_url.into()).expect("Failed to parse the base_url");
 
-		let ver = format!("{}/", version.replace("/", ""));
+		let ver = format!("{}/", version.into().replace("/", ""));
 		debug!("API Version is {}", &ver);
 		HTTPClient {
 			base_url: parsed_url,

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -32,20 +32,20 @@ static TEST_AIVEN_CLIENT: OnceCell<AivenClient> = OnceCell::new();
 pub(crate) fn prepare_test_client() -> &'static AivenClient {
 	TEST_AIVEN_CLIENT.get_or_init(|| {
 		tracing_subscriber::fmt::init();
-		let url = &mockito::server_url();
+		let url = mockito::server_url();
 		println!("Test client not found, recreating {:?}", &url);
 		let token = env::var("AIVEN_TOKEN").unwrap_or_else(|_| "abc".to_string());
-		AivenClient::from_token(url.as_ref(), "", &token)
+		AivenClient::from_token(url, "", &token)
 	})
 }
 
 #[allow(dead_code)]
 pub(crate) fn client() -> &'static AivenClient {
 	TEST_AIVEN_CLIENT.get_or_init(|| {
-		let url = &mockito::server_url();
+		let url = mockito::server_url();
 		println!("Test client not found, recreating {:?}", &url);
 		let token = env::var("AIVEN_TOKEN").unwrap_or_else(|_| "abc".to_string());
-		AivenClient::from_token(url.as_ref(), "", &token)
+		AivenClient::from_token(url, "", &token)
 		// let token = env::var("AIVEN_TOKEN").expect("Please set env variable
 		// to read AIVEN_TOKEN"); AivenClient::from_token("https://api.aiven.io", "v1", &token)
 	})


### PR DESCRIPTION
Make sure all the input parameters are generic, rather than providing
one concrete type, user can provide different types which can be bound
by Into<String>

fixes #44